### PR TITLE
Add exponential backoff for calendar event calls

### DIFF
--- a/backend/functions/api/api_helpers/callWithExponentialBackoff.js
+++ b/backend/functions/api/api_helpers/callWithExponentialBackoff.js
@@ -1,0 +1,20 @@
+const MAX_RETRIES = 5;
+const INITIAL_DELAY_MS = 500;
+
+// Call a function with exponential backoff.
+
+exports.callWithExponentialBackoff = async (fn, args, retryCount = 0) => {
+  try {
+    return await fn(...args);
+  } catch (error) {
+    if (retryCount >= MAX_RETRIES) {
+      console.error(`Failed after ${MAX_RETRIES} retries: ${error}`);
+      throw error;
+    }
+    const delay = INITIAL_DELAY_MS * Math.pow(2, retryCount);
+    const jitter = Math.random() * 1000; // add random delay up to 1 second
+    console.log(`Call failed, retrying after ${delay} ms...`);
+    await new Promise((resolve) => setTimeout(resolve, delay + jitter));
+    return exports.callWithExponentialBackoff(fn, args, retryCount + 1);
+  }
+};


### PR DESCRIPTION
Temporary fix for calendar rate limiting issue, which presumably doesn't occur very often.
 
Google suggests in their [doc](https://developers.google.com/calendar/api/guides/quota#:~:text=doing%20retries%20with%20exponential%20backoff) to make use of an exponential backoff algorithm if quota usage limits are hit. 

The `callWithExponentialBackoff` is designed to progressively wait longer between retries, so if the API limit is temporarily exceeded, it allows some time for the quota to replenish before trying again.

The impact on our application's flow will depend on how often these rate limit issues occur. 

<img width="258" alt="Screenshot 2023-05-10 at 12 25 37 PM" src="https://github.com/sharingexcess/food_rescue_app/assets/5573677/e1770268-6d66-4709-8100-b7b44889e0bd">


If the issue persists then log the calls to google calendar in a separate file and perform backfill.
