### PR TITLE
Update Homepage to show stats and active rescues

### DIFF
--- a/frontend/src/components/Home/Home.AvailableRescues.js
+++ b/frontend/src/components/Home/Home.AvailableRescues.js
@@ -9,16 +9,23 @@ import {
   Text,
 } from '@chakra-ui/react'
 import { FooterButton } from 'components'
-import { formatTimestamp } from 'helpers'
-import { useApi, useIsMobile } from 'hooks'
-import { useMemo } from 'react'
+import { formatTimestamp, STATUSES } from 'helpers'
+import { useApi, useIsMobile, useAuth } from 'hooks'
+import { useEffect, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 
 export function AvailableRescues() {
   const isMobile = useIsMobile()
+  const { user } = useAuth()
+
   const { data: availableRescues } = useApi(
     '/rescues/list',
-    useMemo(() => ({ status: 'scheduled', handler_id: 'null' }), [])
+    useMemo(() => ({ status: STATUSES.SCHEDULED, handler_id: user.id }), [])
+  )
+
+  const { data: activeRescues } = useApi(
+    '/rescues/list',
+    useMemo(() => ({ status: STATUSES.ACTIVE, handler_id: user.id }), [])
   )
 
   function ShowAvailableRescues() {
@@ -31,12 +38,19 @@ export function AvailableRescues() {
     )
   }
 
+  function ShowActiveRescues() {
+    return (
+      <Box pb="24">
+        {activeRescues.map(rescue => (
+          <RescueCard key={rescue.id} rescue={rescue} />
+        ))}
+      </Box>
+    )
+  }
+
   function NoAvailableRescues() {
     return (
       <Flex direction="column" align="center" w="100%" py="8">
-        <Heading size="xl" color="element.secondary" mb="4">
-          😐
-        </Heading>
         <Heading
           as="h4"
           size="sm"
@@ -55,6 +69,25 @@ export function AvailableRescues() {
     )
   }
 
+  function NoActiveRescues() {
+    return (
+      <Flex direction="column" align="center" w="100%" py="8">
+        <Heading size="xl" color="element.secondary" mb="4">
+          😊
+        </Heading>
+        <Heading
+          as="h4"
+          size="sm"
+          color="element.secondary"
+          align="center"
+          mb="2"
+        >
+          You currently have no active rescues.
+        </Heading>
+      </Flex>
+    )
+  }
+
   function LoadingAvailableRescues() {
     return (
       <Box mt="6">
@@ -69,7 +102,7 @@ export function AvailableRescues() {
     <Box px={isMobile ? '4' : '8'} pt="8">
       <Flex w="100%" justify="space-between" align="center">
         <Heading as="h4" color="element.primary" fontSize="lg" my="0">
-          Available Rescues
+          Active Rescues
         </Heading>
         {!isMobile && (
           <Link to="/rescues">
@@ -78,6 +111,21 @@ export function AvailableRescues() {
             </Button>
           </Link>
         )}
+      </Flex>
+      {activeRescues ? (
+        activeRescues.length ? (
+          <ShowActiveRescues />
+        ) : (
+          <NoActiveRescues />
+        )
+      ) : (
+        <LoadingAvailableRescues />
+      )}
+
+      <Flex w="100%" justify="space-between" align="center">
+        <Heading as="h4" color="element.primary" fontSize="lg" my="0">
+          Available Rescues
+        </Heading>
       </Flex>
       {availableRescues ? (
         availableRescues.length ? (
@@ -88,6 +136,7 @@ export function AvailableRescues() {
       ) : (
         <LoadingAvailableRescues />
       )}
+
       {isMobile && (
         <Link to="/rescues">
           <FooterButton>View All Rescues</FooterButton>

--- a/frontend/src/components/Home/Home.Stats.js
+++ b/frontend/src/components/Home/Home.Stats.js
@@ -100,7 +100,11 @@ export function Stats({ totalWeight, totalOrgs, distributions }) {
               <Spinner />
             )}
           </Heading>
-          <Text color="element.tertiary">distributions this year</Text>
+          <Text color="element.tertiary">
+            {stats.totalDistributions == 1
+              ? 'distribution this year'
+              : 'distributions this year'}
+          </Text>
         </Flex>
         <Flex
           p="4"
@@ -125,7 +129,9 @@ export function Stats({ totalWeight, totalOrgs, distributions }) {
               <Spinner />
             )}
           </Heading>
-          <Text color="element.tertiary">individual recipients</Text>
+          <Text color="element.tertiary">
+            {stats.totalOrgs == 1 ? 'recipient' : 'recipients'}
+          </Text>
         </Flex>
       </Flex>
     </Fade>

--- a/frontend/src/components/Home/Home.js
+++ b/frontend/src/components/Home/Home.js
@@ -4,6 +4,7 @@ import moment from 'moment'
 import { useMemo } from 'react'
 import { AvailableRescues } from './Home.AvailableRescues'
 import { Stats } from './Home.Stats'
+import { STATUSES, TRANSFER_TYPES } from 'helpers'
 
 export function Home() {
   const isMobile = useIsMobile()
@@ -12,8 +13,22 @@ export function Home() {
     '/transfers/list',
     useMemo(
       () => ({
-        status: 'completed',
-        type: 'delivery',
+        status: STATUSES.COMPLETED,
+        type: TRANSFER_TYPES.DISTRIBUTION,
+        handler_id: user.id,
+        date_range_start: moment().subtract(1, 'year').format('YYYY-MM-DD'),
+        date_range_finish: moment().format('YYYY-MM-DD'),
+      }),
+      []
+    )
+  )
+
+  const { data: collections } = useApi(
+    '/transfers/list',
+    useMemo(
+      () => ({
+        status: STATUSES.COMPLETED,
+        type: TRANSFER_TYPES.COLLECTION,
         handler_id: user.id,
         date_range_start: moment().subtract(1, 'year').format('YYYY-MM-DD'),
         date_range_finish: moment().format('YYYY-MM-DD'),
@@ -24,12 +39,12 @@ export function Home() {
 
   const totalWeight = useMemo(
     () =>
-      distributions &&
-      distributions.reduce(
+      collections &&
+      collections.reduce(
         (total, current) => (total += current.total_weight),
         0
       ),
-    [distributions]
+    [collections]
   )
 
   const totalOrgs = useMemo(() => {


### PR DESCRIPTION
Re: https://github.com/sharingexcess/food_rescue_app/pull/572

- Update header stats
- Add column for active rescues

<img width="942" alt="Screenshot 2023-06-27 at 8 40 35 PM" src="https://github.com/sharingexcess/food_rescue_app/assets/5573677/3bd8f807-a386-4cb7-9b6c-a57c2c354fa6">