### PR TITLE
Add Rescue Duplication & Date-Ordered Rescues

### DIFF
--- a/frontend/src/components/Home/Home.AvailableRescues.js
+++ b/frontend/src/components/Home/Home.AvailableRescues.js
@@ -31,9 +31,11 @@ export function AvailableRescues() {
   function ShowAvailableRescues() {
     return (
       <Box pb="24">
-        {availableRescues.map(rescue => (
-          <RescueCard key={rescue.id} rescue={rescue} />
-        ))}
+        {availableRescues
+          .sort((a, b) => a.timestamp_scheduled - b.timestamp_scheduled)
+          .map(rescue => (
+            <RescueCard key={rescue.id} rescue={rescue} />
+          ))}
       </Box>
     )
   }

--- a/frontend/src/components/Rescue/Rescue.ActionButtons.js
+++ b/frontend/src/components/Rescue/Rescue.ActionButtons.js
@@ -3,6 +3,7 @@ import {
   ArrowRightIcon,
   EditIcon,
   WarningIcon,
+  CopyIcon,
 } from '@chakra-ui/icons'
 import { Button, Flex } from '@chakra-ui/react'
 import { useRescueContext } from 'components'
@@ -155,6 +156,11 @@ export function RescueActionButtons() {
     }
   }
 
+  async function clearRescueData() {
+    await sessionStorage.removeItem('se_create_rescue_form_data_cache')
+    await sessionStorage.removeItem('se_create_rescue_transfers_cache')
+  }
+
   return (
     <Flex justify="space-between" mb="4" gap="2">
       {rescue.status === STATUSES.SCHEDULED &&
@@ -220,6 +226,25 @@ export function RescueActionButtons() {
             Cancel
           </Button>
         )}
+      {hasAdminPermission && (
+        <Link
+          to={`/schedule-rescue?duplicate=${rescue.id}`}
+          style={{ flexGrow: 1 }}
+        >
+          <Button
+            variant="secondary"
+            size="sm"
+            fontSize="xs"
+            flexGrow="1"
+            leftIcon={<CopyIcon />}
+            bg="blue.secondary"
+            color="green.primary"
+            onClick={clearRescueData}
+          >
+            Duplicate
+          </Button>
+        </Link>
+      )}
     </Flex>
   )
 }


### PR DESCRIPTION
- Implemented functionality for duplicating existing rescues
- Updated Available Rescues list to display in ascending date order

<img width="850" alt="image" src="https://github.com/sharingexcess/food_rescue_app/assets/5573677/27024817-a659-4441-ba2e-963290d4accf">

Transfer list gets carefully copied:

<img width="790" alt="Screenshot 2023-07-13 at 1 03 38 AM" src="https://github.com/sharingexcess/food_rescue_app/assets/5573677/a46d4248-07dc-4f0e-b4c0-d98fd432c245">
