### PR TITLE
Add Rescue Duplication & date-order available rescues

### DIFF
--- a/frontend/src/components/Home/Home.AvailableRescues.js
+++ b/frontend/src/components/Home/Home.AvailableRescues.js
@@ -31,9 +31,11 @@ export function AvailableRescues() {
   function ShowAvailableRescues() {
     return (
       <Box pb="24">
-        {availableRescues.map(rescue => (
-          <RescueCard key={rescue.id} rescue={rescue} />
-        ))}
+        {availableRescues
+          .sort((a, b) => a.timestamp_scheduled - b.timestamp_scheduled)
+          .map(rescue => (
+            <RescueCard key={rescue.id} rescue={rescue} />
+          ))}
       </Box>
     )
   }

--- a/frontend/src/components/Rescue/Rescue.ActionButtons.js
+++ b/frontend/src/components/Rescue/Rescue.ActionButtons.js
@@ -3,6 +3,7 @@ import {
   ArrowRightIcon,
   EditIcon,
   WarningIcon,
+  CopyIcon,
 } from '@chakra-ui/icons'
 import { Button, Flex } from '@chakra-ui/react'
 import { useRescueContext } from 'components'
@@ -155,6 +156,11 @@ export function RescueActionButtons() {
     }
   }
 
+  async function clearRescueData() {
+    await sessionStorage.removeItem('se_create_rescue_form_data_cache')
+    await sessionStorage.removeItem('se_create_rescue_transfers_cache')
+  }
+
   return (
     <Flex justify="space-between" mb="4" gap="2">
       {rescue.status === STATUSES.SCHEDULED &&
@@ -220,6 +226,25 @@ export function RescueActionButtons() {
             Cancel
           </Button>
         )}
+      {hasAdminPermission && (
+        <Link
+          to={`/schedule-rescue?duplicate=${rescue.id}`}
+          style={{ flexGrow: 1 }}
+        >
+          <Button
+            variant="secondary"
+            size="sm"
+            fontSize="xs"
+            flexGrow="1"
+            leftIcon={<CopyIcon />}
+            bg="blue.secondary"
+            color="green.primary"
+            onClick={clearRescueData}
+          >
+            Duplicate
+          </Button>
+        </Link>
+      )}
     </Flex>
   )
 }

--- a/frontend/src/components/ScheduleRescue/ScheduleRescue.js
+++ b/frontend/src/components/ScheduleRescue/ScheduleRescue.js
@@ -11,6 +11,8 @@ import { Transfers } from 'components/ScheduleRescue/ScheduleRescue.Transfers'
 import { InfoForm } from './ScheduleRescue.InfoForm'
 
 export function ScheduleRescue() {
+  const params = new URLSearchParams(window.location.search)
+  const duplicate_rescue_id = params.get('duplicate')
   const { user } = useAuth()
   const { data: handlers } = useApi('/public_profiles/list')
   const { data: donors } = useApi(
@@ -20,6 +22,10 @@ export function ScheduleRescue() {
   const { data: recipients } = useApi(
     '/organizations/list',
     useMemo(() => ({ type: 'recipient' }), [])
+  )
+
+  const { data: duplicate_rescue } = useApi(
+    duplicate_rescue_id ? `/rescues/get/${duplicate_rescue_id}` : null
   )
 
   const form_data_cache = sessionStorage.getItem(
@@ -34,6 +40,7 @@ export function ScheduleRescue() {
           handler: null,
         }
   )
+
   const [view, setView] = useState(null)
   const [working, setWorking] = useState(false)
   const isMobile = useIsMobile()
@@ -45,6 +52,23 @@ export function ScheduleRescue() {
   const [transfers, setTransfers] = useState(
     transfers_cache ? JSON.parse(transfers_cache) : []
   )
+
+  useEffect(() => {
+    if (duplicate_rescue) {
+      duplicate_rescue.transfers.map(transfer => {
+        setTransfers(currentTransfers => [
+          ...currentTransfers,
+          {
+            type: transfer.type,
+            organization: transfer.organization,
+            location: transfer.location,
+            organization_id: transfer.organization.id,
+            location_id: transfer.location.id,
+          },
+        ])
+      })
+    }
+  }, [duplicate_rescue])
 
   useEffect(() => {
     sessionStorage.setItem(
@@ -117,6 +141,12 @@ export function ScheduleRescue() {
     navigate(`/rescues/${rescue.id}`)
   }
 
+  async function handleResetRescue() {
+    await sessionStorage.removeItem('se_create_rescue_transfers_cache')
+    await sessionStorage.removeItem('se_create_rescue_form_data_cache')
+    setTransfers([])
+  }
+
   const isValidRescue =
     formData.timestamp_scheduled &&
     transfers.length >= 2 &&
@@ -171,7 +201,15 @@ export function ScheduleRescue() {
               Add Distribution
             </Button>
           )}
-
+          <Button
+            variant="secondary"
+            onClick={handleResetRescue}
+            flexGrow="1"
+            flexBasis={isMobile ? '100%' : null}
+            background="green.secondary"
+          >
+            Reset
+          </Button>
           <Button
             variant="primary"
             onClick={handleScheduleRescue}


### PR DESCRIPTION
- Implemented functionality for duplicating existing rescues
- Updated Available Rescues list to display in ascending date order

<img width="850" alt="image" src="https://github.com/sharingexcess/food_rescue_app/assets/5573677/27024817-a659-4441-ba2e-963290d4accf">

Transfer list gets carefully copied:

<img width="790" alt="Screenshot 2023-07-13 at 1 03 38 AM" src="https://github.com/sharingexcess/food_rescue_app/assets/5573677/a46d4248-07dc-4f0e-b4c0-d98fd432c245">