### PR TITLE
Add timestamp to retail rescue transfers

### DIFF
--- a/frontend/src/components/Collection/Collection.Header.js
+++ b/frontend/src/components/Collection/Collection.Header.js
@@ -20,7 +20,8 @@ import moment from 'moment'
 
 export function CollectionHeader() {
   const { refresh, setOpenTransfer } = useRescueContext()
-  const { collection, completedAt, setCompletedAt } = useCollectionContext()
+  const { collection, completedAt, setCompletedAt, logRescueType } =
+    useCollectionContext()
   const { user } = useAuth()
 
   async function handleCancel() {
@@ -92,7 +93,11 @@ export function CollectionHeader() {
             {collection.location.notes}
           </Text>
         )}
-      {[STATUSES.CANCELLED, STATUSES.COMPLETED].includes(collection.status) && (
+      {!(
+        logRescueType === 'direct_link' ||
+        logRescueType === 'wholesale' ||
+        logRescueType === 'retail'
+      ) && (
         <>
           <Text
             color="element.tertiary"

--- a/frontend/src/components/Collection/Collection.js
+++ b/frontend/src/components/Collection/Collection.js
@@ -21,6 +21,7 @@ export function Collection({
   collection,
   handleCloseCollectionOverride,
   handleSubmitOverride,
+  logRescueType,
 }) {
   const { user } = useAuth()
   const { setOpenTransfer, rescue, refresh } = useRescueContext()
@@ -53,7 +54,11 @@ export function Collection({
       }
       setEntryRows(initialEntryRows)
       setNotes(collection.notes)
-      setCompletedAt(collection.timestamp_completed)
+      setCompletedAt(
+        collection.timestamp_completed
+          ? moment(collection.timestamp_completed).format('YYYY-MM-DDTHH:mm')
+          : moment().format('YYYY-MM-DDTHH:mm')
+      )
     }
   }, [collection])
 
@@ -71,7 +76,7 @@ export function Collection({
       timestamp_completed:
         // automatically set timestamp completed if this is being submitted for the first time
         collection.status === STATUSES.SCHEDULED
-          ? moment().toISOString()
+          ? moment(completedAt).toISOString()
           : moment(completedAt).toISOString(),
       total_weight: 0,
       categorized_weight: EMPTY_CATEGORIZED_WEIGHT(),
@@ -145,6 +150,7 @@ export function Collection({
     total,
     completedAt,
     setCompletedAt,
+    logRescueType,
   }
 
   return (

--- a/frontend/src/components/Distribution/Distribution.Header.js
+++ b/frontend/src/components/Distribution/Distribution.Header.js
@@ -20,7 +20,8 @@ import moment from 'moment'
 
 export function Header() {
   const { refresh, setOpenTransfer } = useRescueContext()
-  const { distribution, completedAt, setCompletedAt } = useDistributionContext()
+  const { distribution, completedAt, setCompletedAt, logRescueType } =
+    useDistributionContext()
   const { user } = useAuth()
 
   async function handleCancel() {
@@ -92,8 +93,10 @@ export function Header() {
             {distribution.location.notes}
           </Text>
         )}
-      {[STATUSES.CANCELLED, STATUSES.COMPLETED].includes(
-        distribution.status
+      {!(
+        logRescueType === 'direct_link' ||
+        logRescueType === 'wholesale' ||
+        logRescueType === 'retail'
       ) && (
         <>
           <Text

--- a/frontend/src/components/Distribution/Distribution.js
+++ b/frontend/src/components/Distribution/Distribution.js
@@ -22,6 +22,7 @@ export function Distribution({
   rescueOverride,
   handleCloseDistributionOverride,
   handleSubmitOverride,
+  logRescueType,
 }) {
   const { hasAdminPermission, user } = useAuth()
   const { setOpenTransfer, refresh, activeTransfer } = useRescueContext()
@@ -57,7 +58,7 @@ export function Distribution({
       setCompletedAt(
         distribution.timestamp_completed
           ? moment(distribution.timestamp_completed).format('YYYY-MM-DDTHH:mm')
-          : null
+          : moment().format('YYYY-MM-DDTHH:mm')
       )
     }
   }, [distribution, currentLoad])
@@ -94,7 +95,7 @@ export function Distribution({
       timestamp_completed:
         // automatically set timestamp completed if this is being submitted for the first time
         distribution.status === STATUSES.SCHEDULED
-          ? moment().toISOString()
+          ? moment(completedAt).toISOString()
           : moment(completedAt).toISOString(),
       total_weight,
       categorized_weight,
@@ -153,6 +154,7 @@ export function Distribution({
     isSubmitting,
     completedAt,
     setCompletedAt,
+    logRescueType,
   }
 
   return (

--- a/frontend/src/components/LogRescue/LogRescue.js
+++ b/frontend/src/components/LogRescue/LogRescue.js
@@ -120,6 +120,9 @@ export function LogRescue() {
           timestamp_completed: moment(
             formData.timestamp_completed
           ).toISOString(),
+          rescue_scheduled_time: moment(
+            formData.timestamp_scheduled
+          ).toISOString(),
         })),
       },
       user.accessToken
@@ -204,6 +207,7 @@ export function LogRescue() {
           collection={activeTransfer}
           handleSubmitOverride={handleUpdateCollection}
           handleCloseCollectionOverride={() => setActiveTransfer(null)}
+          logRescueType={formData.type ? formData.type : null}
         />
       ) : activeTransfer?.type === TRANSFER_TYPES.DISTRIBUTION ? (
         <Distribution
@@ -211,6 +215,7 @@ export function LogRescue() {
           rescueOverride={{ transfers }}
           handleCloseDistributionOverride={() => setActiveTransfer(null)}
           handleSubmitOverride={handleUpdateDistribution}
+          logRescueType={formData.type ? formData.type : null}
         />
       ) : null}
       {view ? (


### PR DESCRIPTION
Add timestamp input to retail rescue transfers for accurate logging of data.